### PR TITLE
fix: unify author name (tomlo → tsunamayo7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ PyQt6製のAIオーケストレーションデスクトップアプリ + FastAPI
 Claude CLI / Anthropic API / OpenAI API / Google Gemini API / Ollama（ローカルLLM）を
 5Phaseパイプラインで統合する。
 
-- **オーナー**: tomlo (tsunamayo7)
-- **LICENSE著作者名**: tomlo
+- **オーナー**: tsunamayo7
+- **LICENSE著作者名**: tsunamayo7
 - **言語**: 日本語/英語（i18n対応）
 - **実行環境**: Windows 11（デスクトップ）+ モバイルブラウザ（Web UI）
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 tomlo and Helix AI Studio Contributors
+Copyright (c) 2026 tsunamayo7 and Helix AI Studio Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -295,6 +295,6 @@ For security issues, see [SECURITY.md](SECURITY.md).
 
 MIT -- see [LICENSE](LICENSE)
 
-**Author**: tomlo ([@tsunamayo7](https://github.com/tsunamayo7))
+**Author**: tsunamayo7 ([@tsunamayo7](https://github.com/tsunamayo7))
 
 If Helix AI Studio is useful to you, please give it a star! Feedback, issues, and PRs are always welcome.

--- a/README_ja.md
+++ b/README_ja.md
@@ -295,6 +295,6 @@ python HelixAIStudio.py
 
 MIT -- [LICENSE](LICENSE) を参照
 
-**作者**: tomlo ([@tsunamayo7](https://github.com/tsunamayo7))
+**作者**: tsunamayo7 ([@tsunamayo7](https://github.com/tsunamayo7))
 
 Helix AI Studio が役に立ったら、ぜひスターをお願いします！フィードバック、Issue、PRはいつでも歓迎です。

--- a/version_info.txt
+++ b/version_info.txt
@@ -13,11 +13,11 @@ VSVersionInfo(
     StringFileInfo([
       StringTable(
         u'040904B0',
-        [StringStruct(u'CompanyName', u'tomlo'),
+        [StringStruct(u'CompanyName', u'tsunamayo7'),
          StringStruct(u'FileDescription', u'Helix AI Studio'),
          StringStruct(u'FileVersion', u'11.9.0.0'),
          StringStruct(u'InternalName', u'HelixAIStudio'),
-         StringStruct(u'LegalCopyright', u'Copyright (c) 2026 tomlo'),
+         StringStruct(u'LegalCopyright', u'Copyright (c) 2026 tsunamayo7'),
          StringStruct(u'OriginalFilename', u'HelixAIStudio.exe'),
          StringStruct(u'ProductName', u'Helix AI Studio'),
          StringStruct(u'ProductVersion', u'11.9.0.0')])


### PR DESCRIPTION
## Summary
- Replaced all instances of "tomlo" with "tsunamayo7" across public-facing files
- Updated: LICENSE, README.md, README_ja.md, CLAUDE.md, version_info.txt
- Ensures consistent public identity across GitHub profile and repository

## Files Changed
| File | Change |
|------|--------|
| LICENSE | Copyright holder: `tomlo` → `tsunamayo7` |
| README.md | Author credit: `tomlo` → `tsunamayo7` |
| README_ja.md | Author credit: `tomlo` → `tsunamayo7` |
| CLAUDE.md | Owner/license fields: `tomlo` → `tsunamayo7` |
| version_info.txt | CompanyName + LegalCopyright: `tomlo` → `tsunamayo7` |

## Test plan
- [x] Verified no remaining "tomlo" references in any git-tracked files via `grep -r`
- [x] No personal info (paths, API keys, "tomot") exposed in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)